### PR TITLE
dev: update testchain docker image

### DIFF
--- a/docker/Dockerfile.testchain
+++ b/docker/Dockerfile.testchain
@@ -7,9 +7,13 @@ RUN apt-get update && apt-get install -y \
 
 RUN mkdir /testchain
 
-RUN git clone https://github.com/layerTwo-Labs/testchain /testchain
+ARG TESTCHAIN_VERSION
+RUN git clone --depth 1 \
+    https://github.com/layerTwo-Labs/testchain /testchain
 
 WORKDIR /testchain
+
+RUN git checkout $TESTCHAIN_VERSION
 
 RUN ./autogen.sh
 RUN ./configure --with-incompatible-bdb

--- a/docker/build-push-image-testchain.sh
+++ b/docker/build-push-image-testchain.sh
@@ -1,2 +1,15 @@
-docker buildx build -t barebitcoin/testchain --file Dockerfile.testchain . 
+set -e
+set -o pipefail
+
+REPO=LayerTwo-Labs/testchain
+MAIN_BRANCH=testchain
+
+TESTCHAIN_VERSION=$(gh api repos/$REPO/git/ref/heads/$MAIN_BRANCH | jq --raw-output .object.sha)
+
+echo Building Docker image based off SHA $TESTCHAIN_VERSION
+
+docker buildx build \
+    --build-arg TESTCHAIN_VERSION=$TESTCHAIN_VERSION \
+    -t barebitcoin/testchain \
+    --file Dockerfile.testchain . 
 docker push barebitcoin/testchain


### PR DESCRIPTION
A call to the testchain build script will fetch the most recent master commit, and build that. This ensures that builds will be new every time master updates.