### PR TITLE
deps: bump dart_coin_rpc version

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -189,8 +189,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: master
-      resolved-ref: cbbe7e98a95d2d43dd4f53038a73eca5dafb64cb
+      ref: ca2f50ed899386c5fb8f144b1c438b8673f23e22
+      resolved-ref: ca2f50ed899386c5fb8f144b1c438b8673f23e22
       url: "https://github.com/barebitcoin/dart_coin_rpc.git"
     source: git
     version: "2.1.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,8 @@ dependencies:
   dart_coin_rpc:
     git:
       url: https://github.com/barebitcoin/dart_coin_rpc.git
-      ref: master
+      # master, as of 08.11.2023
+      ref: ca2f50ed899386c5fb8f144b1c438b8673f23e22
   flutter_highlighter: ^0.1.1
   logger: ^2.0.2+1
   dio: ^4.0.6


### PR DESCRIPTION
Includes https://github.com/barebitcoin/dart_coin_rpc/commit/ca2f50ed899386c5fb8f144b1c438b8673f23e22 from our fork