### PR TITLE
zcash custom transfer tab

### DIFF
--- a/packages/sidesail/lib/pages/tabs/dashboard_tab_page.dart
+++ b/packages/sidesail/lib/pages/tabs/dashboard_tab_page.dart
@@ -109,7 +109,7 @@ class DashboardTabViewModel extends BaseViewModel {
   TransactionsProvider get _transactionsProvider => GetIt.I.get<TransactionsProvider>();
   SidechainContainer get _sideRPC => GetIt.I.get<SidechainContainer>();
 
-  List<CoreTransaction> get transactions => _transactionsProvider.transactions;
+  List<CoreTransaction> get transactions => _transactionsProvider.sidechainTransactions;
 
   Sidechain get chain => _sideRPC.rpc.chain;
 

--- a/packages/sidesail/lib/pages/tabs/home_page.dart
+++ b/packages/sidesail/lib/pages/tabs/home_page.dart
@@ -75,6 +75,7 @@ class _HomePageState extends State<HomePage> {
       ZCashMeltCastTabRoute(),
       ZCashShieldDeshieldTabRoute(),
       ZCashRPCTabRoute(),
+      ZCashTransferTabRoute(),
 
       // trailing common routes
       NodeSettingsTabRoute(),
@@ -436,9 +437,9 @@ class _SideNavState extends State<SideNav> {
             subs: [
               SubNavEntry(
                 title: 'Transfer',
-                selected: tabsRouter.activeIndex == TestchainHome,
+                selected: tabsRouter.activeIndex == ZCashHome + 3,
                 onPressed: () {
-                  tabsRouter.setActiveIndex(TestchainHome);
+                  tabsRouter.setActiveIndex(ZCashHome + 3);
                 },
               ),
               SubNavEntry(

--- a/packages/sidesail/lib/pages/tabs/home_page.dart
+++ b/packages/sidesail/lib/pages/tabs/home_page.dart
@@ -72,8 +72,8 @@ class _HomePageState extends State<HomePage> {
       EthereumRPCTabRoute(),
 
       // zcash routes
-      ZCashCastTabRoute(),
-      ZCashShieldTabRoute(),
+      ZCashMeltCastTabRoute(),
+      ZCashShieldDeshieldTabRoute(),
       ZCashRPCTabRoute(),
 
       // trailing common routes

--- a/packages/sidesail/lib/pages/tabs/zcash/zcash_melt_cast_page.dart
+++ b/packages/sidesail/lib/pages/tabs/zcash/zcash_melt_cast_page.dart
@@ -16,10 +16,10 @@ import 'package:sidesail/widgets/containers/tabs/zcash_tab_widgets.dart';
 import 'package:stacked/stacked.dart';
 
 @RoutePage()
-class ZCashCastTabPage extends StatelessWidget {
+class ZCashMeltCastTabPage extends StatelessWidget {
   AppRouter get router => GetIt.I.get<AppRouter>();
 
-  const ZCashCastTabPage({super.key});
+  const ZCashMeltCastTabPage({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -292,7 +292,6 @@ class ZCashCastTabViewModel extends BaseViewModel {
   }
 }
 
-@RoutePage()
 class ZCashWidgetTitle extends ViewModelWidget<ZCashCastTabViewModel> {
   final VoidCallback depositNudgeAction;
 

--- a/packages/sidesail/lib/pages/tabs/zcash/zcash_melt_cast_page.dart
+++ b/packages/sidesail/lib/pages/tabs/zcash/zcash_melt_cast_page.dart
@@ -6,6 +6,7 @@ import 'package:sail_ui/sail_ui.dart';
 import 'package:sail_ui/theme/theme.dart';
 import 'package:sail_ui/widgets/core/sail_text.dart';
 import 'package:sidesail/pages/tabs/home_page.dart';
+import 'package:sidesail/pages/tabs/zcash/zcash_transfer_page.dart';
 import 'package:sidesail/providers/balance_provider.dart';
 import 'package:sidesail/providers/cast_provider.dart';
 import 'package:sidesail/providers/zcash_provider.dart';
@@ -289,60 +290,5 @@ class ZCashCastTabViewModel extends BaseViewModel {
     super.dispose();
     _zcashProvider.removeListener(notifyListeners);
     _balanceProvider.removeListener(notifyListeners);
-  }
-}
-
-class ZCashWidgetTitle extends ViewModelWidget<ZCashCastTabViewModel> {
-  final VoidCallback depositNudgeAction;
-
-  AppRouter get router => GetIt.I.get<AppRouter>();
-
-  const ZCashWidgetTitle({
-    super.key,
-    required this.depositNudgeAction,
-  });
-
-  @override
-  Widget build(BuildContext context, ZCashCastTabViewModel viewModel) {
-    if (viewModel.balance != 0) {
-      return SailRow(
-        spacing: SailStyleValues.padding08,
-        children: [
-          SailText.secondary13('Your ZCash-address: ${viewModel.zcashAddress}'),
-          Expanded(child: Container()),
-        ],
-      );
-    }
-
-    return SailRow(
-      spacing: SailStyleValues.padding08,
-      children: [
-        SailButton.primary(
-          'Deposit coins',
-          onPressed: () async {
-            try {
-              depositNudgeAction();
-            } catch (err) {
-              if (!context.mounted) {
-                return;
-              }
-
-              await errorDialog(
-                context: context,
-                action: 'Deposit coins',
-                title: 'Could not move to deposit tab',
-                subtitle: err.toString(),
-              );
-            }
-          },
-          loading: viewModel.isBusy,
-          size: ButtonSize.small,
-        ),
-        SailText.secondary12(
-          'To get started, you must deposit coins to your sidechain. Peg-In on the Parent Chain tab',
-        ),
-        Expanded(child: Container()),
-      ],
-    );
   }
 }

--- a/packages/sidesail/lib/pages/tabs/zcash/zcash_shield_deshield_page.dart
+++ b/packages/sidesail/lib/pages/tabs/zcash/zcash_shield_deshield_page.dart
@@ -6,6 +6,7 @@ import 'package:sail_ui/sail_ui.dart';
 import 'package:sail_ui/theme/theme.dart';
 import 'package:sail_ui/widgets/core/sail_text.dart';
 import 'package:sidesail/pages/tabs/home_page.dart';
+import 'package:sidesail/pages/tabs/zcash/zcash_transfer_page.dart';
 import 'package:sidesail/providers/balance_provider.dart';
 import 'package:sidesail/providers/zcash_provider.dart';
 import 'package:sidesail/routing/router.dart';
@@ -202,60 +203,5 @@ class ZCashShieldTabViewModel extends BaseViewModel {
     super.dispose();
     _zcashProvider.removeListener(notifyListeners);
     _balanceProvider.removeListener(notifyListeners);
-  }
-}
-
-class ZCashWidgetTitle extends ViewModelWidget<ZCashShieldTabViewModel> {
-  final VoidCallback depositNudgeAction;
-
-  AppRouter get router => GetIt.I.get<AppRouter>();
-
-  const ZCashWidgetTitle({
-    super.key,
-    required this.depositNudgeAction,
-  });
-
-  @override
-  Widget build(BuildContext context, ZCashShieldTabViewModel viewModel) {
-    if (viewModel.balance != 0) {
-      return SailRow(
-        spacing: SailStyleValues.padding08,
-        children: [
-          SailText.secondary13('Your ZCash-address: ${viewModel.zcashAddress}'),
-          Expanded(child: Container()),
-        ],
-      );
-    }
-
-    return SailRow(
-      spacing: SailStyleValues.padding08,
-      children: [
-        SailButton.primary(
-          'Deposit coins',
-          onPressed: () async {
-            try {
-              depositNudgeAction();
-            } catch (err) {
-              if (!context.mounted) {
-                return;
-              }
-
-              await errorDialog(
-                context: context,
-                action: 'Deposit coins',
-                title: 'Could not move to deposit tab',
-                subtitle: err.toString(),
-              );
-            }
-          },
-          loading: viewModel.isBusy,
-          size: ButtonSize.small,
-        ),
-        SailText.secondary12(
-          'To get started, you must deposit coins to your sidechain. Peg-In on the Parent Chain tab',
-        ),
-        Expanded(child: Container()),
-      ],
-    );
   }
 }

--- a/packages/sidesail/lib/pages/tabs/zcash/zcash_shield_deshield_page.dart
+++ b/packages/sidesail/lib/pages/tabs/zcash/zcash_shield_deshield_page.dart
@@ -15,10 +15,10 @@ import 'package:sidesail/widgets/containers/tabs/zcash_tab_widgets.dart';
 import 'package:stacked/stacked.dart';
 
 @RoutePage()
-class ZCashShieldTabPage extends StatelessWidget {
+class ZCashShieldDeshieldTabPage extends StatelessWidget {
   AppRouter get router => GetIt.I.get<AppRouter>();
 
-  const ZCashShieldTabPage({super.key});
+  const ZCashShieldDeshieldTabPage({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -205,7 +205,6 @@ class ZCashShieldTabViewModel extends BaseViewModel {
   }
 }
 
-@RoutePage()
 class ZCashWidgetTitle extends ViewModelWidget<ZCashShieldTabViewModel> {
   final VoidCallback depositNudgeAction;
 

--- a/packages/sidesail/lib/pages/tabs/zcash/zcash_transfer_page.dart
+++ b/packages/sidesail/lib/pages/tabs/zcash/zcash_transfer_page.dart
@@ -218,3 +218,86 @@ class ZCashTransferTabViewModel extends BaseViewModel {
     _transactionsProvider.removeListener(notifyListeners);
   }
 }
+
+class ZCashWidgetTitle extends StatelessWidget {
+  final VoidCallback depositNudgeAction;
+
+  AppRouter get router => GetIt.I.get<AppRouter>();
+
+  const ZCashWidgetTitle({
+    super.key,
+    required this.depositNudgeAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewModelBuilder.reactive(
+      viewModelBuilder: () => ZCashWidgetTitleViewModel(),
+      builder: ((context, viewModel, child) {
+        if (viewModel.balance != 0) {
+          return SailRow(
+            spacing: SailStyleValues.padding08,
+            children: [
+              SailText.secondary13('Your ZCash-address: ${viewModel.zcashAddress}'),
+              Expanded(child: Container()),
+            ],
+          );
+        }
+
+        return SailRow(
+          spacing: SailStyleValues.padding08,
+          children: [
+            SailButton.primary(
+              'Deposit coins',
+              onPressed: () async {
+                try {
+                  depositNudgeAction();
+                } catch (err) {
+                  if (!context.mounted) {
+                    return;
+                  }
+
+                  await errorDialog(
+                    context: context,
+                    action: 'Deposit coins',
+                    title: 'Could not move to deposit tab',
+                    subtitle: err.toString(),
+                  );
+                }
+              },
+              loading: viewModel.isBusy,
+              size: ButtonSize.small,
+            ),
+            SailText.secondary12(
+              'To get started, you must deposit coins to your sidechain. Peg-In on the Parent Chain tab',
+            ),
+            Expanded(child: Container()),
+          ],
+        );
+      }),
+    );
+  }
+}
+
+class ZCashWidgetTitleViewModel extends BaseViewModel {
+  final log = Logger(level: Level.debug);
+  ZCashProvider get _zcashProvider => GetIt.I.get<ZCashProvider>();
+  BalanceProvider get _balanceProvider => GetIt.I.get<BalanceProvider>();
+
+  String get zcashAddress => _zcashProvider.zcashAddress;
+  double get balance => _balanceProvider.balance + _balanceProvider.pendingBalance;
+
+  bool showAll = false;
+
+  ZCashWidgetTitleViewModel() {
+    _zcashProvider.addListener(notifyListeners);
+    _balanceProvider.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _zcashProvider.removeListener(notifyListeners);
+    _balanceProvider.removeListener(notifyListeners);
+  }
+}

--- a/packages/sidesail/lib/pages/tabs/zcash/zcash_transfer_page.dart
+++ b/packages/sidesail/lib/pages/tabs/zcash/zcash_transfer_page.dart
@@ -1,0 +1,220 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sail_ui/theme/theme.dart';
+import 'package:sail_ui/widgets/core/sail_text.dart';
+import 'package:sidesail/pages/tabs/home_page.dart';
+import 'package:sidesail/providers/balance_provider.dart';
+import 'package:sidesail/providers/transactions_provider.dart';
+import 'package:sidesail/providers/zcash_provider.dart';
+import 'package:sidesail/routing/router.dart';
+import 'package:sidesail/rpc/models/core_transaction.dart';
+import 'package:sidesail/rpc/models/zcash_utxos.dart';
+import 'package:sidesail/widgets/containers/tabs/dashboard_tab_widgets.dart';
+import 'package:stacked/stacked.dart';
+
+@RoutePage()
+class ZCashTransferTabPage extends StatelessWidget {
+  AppRouter get router => GetIt.I.get<AppRouter>();
+
+  const ZCashTransferTabPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+
+    return ViewModelBuilder.reactive(
+      viewModelBuilder: () => ZCashTransferTabViewModel(),
+      builder: ((context, viewModel, child) {
+        final tabsRouter = AutoTabsRouter.of(context);
+
+        return SailPage(
+          scrollable: true,
+          widgetTitle: ZCashWidgetTitle(
+            depositNudgeAction: () => tabsRouter.setActiveIndex(ParentChainHome),
+          ),
+          body: Padding(
+            padding: const EdgeInsets.only(bottom: SailStyleValues.padding30),
+            child: SailColumn(
+              spacing: SailStyleValues.padding30,
+              children: [
+                SailRow(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  spacing: 0,
+                  children: [
+                    Flexible(
+                      child: SailColumn(
+                        spacing: SailStyleValues.padding30,
+                        children: [
+                          DashboardGroup(
+                            title: 'Transparent coins',
+                            children: [
+                              ActionTile(
+                                title: 'Send transparent coins',
+                                category: Category.sidechain,
+                                icon: Icons.remove,
+                                onTap: () {
+                                  viewModel.sendTransparent(context);
+                                },
+                              ),
+                              ActionTile(
+                                title: 'Receive transparent coins',
+                                category: Category.sidechain,
+                                icon: Icons.remove,
+                                onTap: () {
+                                  viewModel.receiveTransparent(context);
+                                },
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    VerticalDivider(
+                      width: 1,
+                      thickness: 1,
+                      color: theme.colors.divider,
+                    ),
+                    Flexible(
+                      child: SailColumn(
+                        spacing: SailStyleValues.padding30,
+                        children: [
+                          DashboardGroup(
+                            title: 'Private coins',
+                            children: [
+                              ActionTile(
+                                title: 'Send private coins',
+                                category: Category.sidechain,
+                                icon: Icons.remove,
+                                onTap: () {
+                                  viewModel.sendPrivate(context);
+                                },
+                              ),
+                              ActionTile(
+                                title: 'Receive private coins',
+                                category: Category.sidechain,
+                                icon: Icons.add,
+                                onTap: () {
+                                  viewModel.receivePrivate(context);
+                                },
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                DashboardGroup(
+                  title: 'Transactions',
+                  widgetTrailing: SailText.secondary13(viewModel.transactions.length.toString()),
+                  children: [
+                    SailColumn(
+                      spacing: 0,
+                      withDivider: true,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        for (final tx in viewModel.transactions)
+                          CoreTransactionView(
+                            tx: tx,
+                          ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class ZCashTransferTabViewModel extends BaseViewModel {
+  final log = Logger(level: Level.debug);
+  ZCashProvider get _zcashProvider => GetIt.I.get<ZCashProvider>();
+  BalanceProvider get _balanceProvider => GetIt.I.get<BalanceProvider>();
+  TransactionsProvider get _transactionsProvider => GetIt.I.get<TransactionsProvider>();
+
+  String get zcashAddress => _zcashProvider.zcashAddress;
+  List<OperationStatus> get operations => _zcashProvider.operations.reversed.toList();
+  List<UnshieldedUTXO> get unshieldedUTXOs =>
+      _zcashProvider.unshieldedUTXOs.where((u) => showAll || u.amount > 0.0001).toList();
+  List<ShieldedUTXO> get shieldedUTXOs => _zcashProvider.shieldedUTXOs;
+  List<CoreTransaction> get transactions => _transactionsProvider.sidechainTransactions;
+
+  double get balance => _balanceProvider.balance + _balanceProvider.pendingBalance;
+
+  bool showAll = false;
+
+  void setShowAll(bool to) {
+    showAll = to;
+    notifyListeners();
+  }
+
+  ZCashTransferTabViewModel() {
+    _zcashProvider.addListener(notifyListeners);
+    _balanceProvider.addListener(notifyListeners);
+    _transactionsProvider.addListener(notifyListeners);
+  }
+
+  void sendPrivate(BuildContext context) async {
+    await showThemedDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return const SendOnSidechainAction();
+      },
+    );
+  }
+
+  void receivePrivate(BuildContext context) async {
+    await showThemedDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return const ReceiveOnSidechainAction();
+      },
+    );
+  }
+
+  void sendTransparent(BuildContext context) async {
+    await showThemedDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return SendOnSidechainAction(
+          customSendAction: (address, amount) async {
+            return await _zcashProvider.rpc.sendTransparent(
+              address,
+              amount,
+              false,
+            );
+          },
+        );
+      },
+    );
+  }
+
+  void receiveTransparent(BuildContext context) async {
+    await showThemedDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return ReceiveOnSidechainAction(
+          customReceiveAction: () async {
+            return await _zcashProvider.rpc.getTransparentAddress();
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _zcashProvider.removeListener(notifyListeners);
+    _balanceProvider.removeListener(notifyListeners);
+    _transactionsProvider.removeListener(notifyListeners);
+  }
+}

--- a/packages/sidesail/lib/providers/transactions_provider.dart
+++ b/packages/sidesail/lib/providers/transactions_provider.dart
@@ -17,7 +17,7 @@ class TransactionsProvider extends ChangeNotifier {
   // to this class will be notified of changes to these
   // variables.
   List<UTXO> unspentMainchainUTXOs = [];
-  List<CoreTransaction> transactions = [];
+  List<CoreTransaction> sidechainTransactions = [];
   bool initialized = false;
 
   // used for polling
@@ -30,8 +30,8 @@ class TransactionsProvider extends ChangeNotifier {
 
   // call this function from anywhere to refetch transaction list
   Future<void> fetch() async {
-    transactions = await sidechain.rpc.listTransactions();
-    transactions = transactions.reversed.toList();
+    sidechainTransactions = await sidechain.rpc.listTransactions();
+    sidechainTransactions = sidechainTransactions.reversed.toList();
 
     unspentMainchainUTXOs = await _mainchainRPC.listUnspent();
     unspentMainchainUTXOs = unspentMainchainUTXOs.reversed.toList();

--- a/packages/sidesail/lib/routing/router.dart
+++ b/packages/sidesail/lib/routing/router.dart
@@ -12,9 +12,9 @@ import 'package:sidesail/pages/tabs/testchain/mainchain/bmm_tab_page.dart';
 import 'package:sidesail/pages/tabs/testchain/mainchain/transfer_mainchain_tab_route.dart';
 import 'package:sidesail/pages/tabs/testchain/mainchain/withdrawal_bundle_tab_page.dart';
 import 'package:sidesail/pages/tabs/testchain/testchain_rpc_tab_page.dart';
-import 'package:sidesail/pages/tabs/zcash/zcash_cast_page.dart';
+import 'package:sidesail/pages/tabs/zcash/zcash_melt_cast_page.dart';
 import 'package:sidesail/pages/tabs/zcash/zcash_rpc_tab_page.dart';
-import 'package:sidesail/pages/tabs/zcash/zcash_shield_page.dart';
+import 'package:sidesail/pages/tabs/zcash/zcash_shield_deshield_page.dart';
 import 'package:sidesail/pages/test_page.dart';
 
 part 'router.gr.dart';
@@ -65,11 +65,11 @@ class AppRouter extends _$AppRouter {
               initial: RuntimeArgs.chain.toLowerCase() == EthereumSidechain().name.toLowerCase() ? true : false,
             ),
             AutoRoute(
-              page: ZCashCastTabRoute.page,
+              page: ZCashMeltCastTabRoute.page,
               initial: RuntimeArgs.chain.toLowerCase() == ZCashSidechain().name.toLowerCase() ? true : false,
             ),
             AutoRoute(
-              page: ZCashShieldTabRoute.page,
+              page: ZCashShieldDeshieldTabRoute.page,
             ),
             AutoRoute(
               page: ZCashRPCTabRoute.page,

--- a/packages/sidesail/lib/routing/router.dart
+++ b/packages/sidesail/lib/routing/router.dart
@@ -15,6 +15,7 @@ import 'package:sidesail/pages/tabs/testchain/testchain_rpc_tab_page.dart';
 import 'package:sidesail/pages/tabs/zcash/zcash_melt_cast_page.dart';
 import 'package:sidesail/pages/tabs/zcash/zcash_rpc_tab_page.dart';
 import 'package:sidesail/pages/tabs/zcash/zcash_shield_deshield_page.dart';
+import 'package:sidesail/pages/tabs/zcash/zcash_transfer_page.dart';
 import 'package:sidesail/pages/test_page.dart';
 
 part 'router.gr.dart';
@@ -70,6 +71,9 @@ class AppRouter extends _$AppRouter {
             ),
             AutoRoute(
               page: ZCashShieldDeshieldTabRoute.page,
+            ),
+            AutoRoute(
+              page: ZCashTransferTabRoute.page,
             ),
             AutoRoute(
               page: ZCashRPCTabRoute.page,

--- a/packages/sidesail/lib/routing/router.gr.dart
+++ b/packages/sidesail/lib/routing/router.gr.dart
@@ -85,10 +85,10 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const WithdrawalBundleTabPage(),
       );
     },
-    ZCashCastTabRoute.name: (routeData) {
+    ZCashMeltCastTabRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const ZCashCastTabPage(),
+        child: const ZCashMeltCastTabPage(),
       );
     },
     ZCashRPCTabRoute.name: (routeData) {
@@ -97,7 +97,12 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const ZCashRPCTabPage(),
       );
     },
-    ZCashShieldTabRoute.name: (routeData) {
+    ZCashShieldDeshieldTabRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const ZCashShieldDeshieldTabPage(),
+      );
+    },
       return AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const ZCashShieldTabPage(),
@@ -284,15 +289,15 @@ class WithdrawalBundleTabRoute extends PageRouteInfo<void> {
 }
 
 /// generated route for
-/// [ZCashCastTabPage]
-class ZCashCastTabRoute extends PageRouteInfo<void> {
-  const ZCashCastTabRoute({List<PageRouteInfo>? children})
+/// [ZCashMeltCastTabPage]
+class ZCashMeltCastTabRoute extends PageRouteInfo<void> {
+  const ZCashMeltCastTabRoute({List<PageRouteInfo>? children})
       : super(
-          ZCashCastTabRoute.name,
+          ZCashMeltCastTabRoute.name,
           initialChildren: children,
         );
 
-  static const String name = 'ZCashCastTabRoute';
+  static const String name = 'ZCashMeltCastTabRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
 }
@@ -312,15 +317,15 @@ class ZCashRPCTabRoute extends PageRouteInfo<void> {
 }
 
 /// generated route for
-/// [ZCashShieldTabPage]
-class ZCashShieldTabRoute extends PageRouteInfo<void> {
-  const ZCashShieldTabRoute({List<PageRouteInfo>? children})
+/// [ZCashShieldDeshieldTabPage]
+class ZCashShieldDeshieldTabRoute extends PageRouteInfo<void> {
+  const ZCashShieldDeshieldTabRoute({List<PageRouteInfo>? children})
       : super(
-          ZCashShieldTabRoute.name,
+          ZCashShieldDeshieldTabRoute.name,
           initialChildren: children,
         );
 
-  static const String name = 'ZCashShieldTabRoute';
+  static const String name = 'ZCashShieldDeshieldTabRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
 }

--- a/packages/sidesail/lib/routing/router.gr.dart
+++ b/packages/sidesail/lib/routing/router.gr.dart
@@ -103,9 +103,10 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const ZCashShieldDeshieldTabPage(),
       );
     },
+    ZCashTransferTabRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const ZCashShieldTabPage(),
+        child: const ZCashTransferTabPage(),
       );
     },
   };
@@ -331,38 +332,15 @@ class ZCashShieldDeshieldTabRoute extends PageRouteInfo<void> {
 }
 
 /// generated route for
-/// [ZCashWidgetTitle]
-class ZCashWidgetTitle extends PageRouteInfo<ZCashWidgetTitleArgs> {
-  ZCashWidgetTitle({
-    Key? key,
-    required void Function() depositNudgeAction,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ZCashWidgetTitle.name,
-          args: ZCashWidgetTitleArgs(
-            key: key,
-            depositNudgeAction: depositNudgeAction,
-          ),
+/// [ZCashTransferTabPage]
+class ZCashTransferTabRoute extends PageRouteInfo<void> {
+  const ZCashTransferTabRoute({List<PageRouteInfo>? children})
+      : super(
+          ZCashTransferTabRoute.name,
           initialChildren: children,
         );
 
-  static const String name = 'ZCashWidgetTitle';
+  static const String name = 'ZCashTransferTabRoute';
 
-  static const PageInfo<ZCashWidgetTitleArgs> page = PageInfo<ZCashWidgetTitleArgs>(name);
-}
-
-class ZCashWidgetTitleArgs {
-  const ZCashWidgetTitleArgs({
-    this.key,
-    required this.depositNudgeAction,
-  });
-
-  final Key? key;
-
-  final void Function() depositNudgeAction;
-
-  @override
-  String toString() {
-    return 'ZCashWidgetTitleArgs{key: $key, depositNudgeAction: $depositNudgeAction}';
-  }
+  static const PageInfo<void> page = PageInfo<void>(name);
 }

--- a/packages/sidesail/lib/widgets/containers/tabs/zcash_tab_widgets.dart
+++ b/packages/sidesail/lib/widgets/containers/tabs/zcash_tab_widgets.dart
@@ -263,7 +263,7 @@ class DeshieldUTXOActionViewModel extends BaseViewModel {
   }
 
   void init() async {
-    deshieldAddress = await _rpc.getNewAddress();
+    deshieldAddress = await _rpc.getTransparentAddress();
     notifyListeners();
   }
 
@@ -409,10 +409,10 @@ class CastSingleUTXOActionViewModel extends BaseViewModel {
   }
 
   void init() async {
-    castAddresses.add(await _rpc.getNewAddress());
-    castAddresses.add(await _rpc.getNewAddress());
-    castAddresses.add(await _rpc.getNewAddress());
-    castAddresses.add(await _rpc.getNewAddress());
+    castAddresses.add(await _rpc.getTransparentAddress());
+    castAddresses.add(await _rpc.getTransparentAddress());
+    castAddresses.add(await _rpc.getTransparentAddress());
+    castAddresses.add(await _rpc.getTransparentAddress());
 
     notifyListeners();
   }

--- a/packages/sidesail/test/mocks/rpc_mock_zcash.dart
+++ b/packages/sidesail/test/mocks/rpc_mock_zcash.dart
@@ -284,12 +284,17 @@ class MockZCashRPC extends ZCashRPC {
   }
 
   @override
-  Future<String> getNewAddress() async {
+  Future<String> getTransparentAddress() async {
     return 'tmBd8jBt7FGDjN8KL9Wh4s925R6EopAGacu';
   }
 
   @override
   Future<void> stopNode() async {
     return;
+  }
+
+  @override
+  Future<String> sendTransparent(String address, double amount, bool subtractFeeFromAmount) async {
+    return 'txiddeadbeef';
   }
 }


### PR DESCRIPTION
- tabs/zcash: RENAME ONLY
- providers/transactions: better naming of transactions
- rpc/zcash: add sendTransparent and getTransparentAddress functions
- widgets/dashboard: add custom functions for send/receive sidechain-actions
- tabs/zcash: add unique sidechain-transfer page for zcash
- tabs/zcash: separate widget title into it's own viewmodel
