### PR TITLE
2024 01 26 more zcash

### DIFF
--- a/packages/sail_ui/lib/sail_ui.dart
+++ b/packages/sail_ui/lib/sail_ui.dart
@@ -7,6 +7,7 @@ export './widgets/chips/action_header_chip.dart';
 export './widgets/chips/connection_error_chip.dart';
 export './widgets/chips/connection_success_chip.dart';
 export './widgets/containers/action_tile.dart';
+export './widgets/containers/notification.dart';
 export './widgets/containers/sail_border.dart';
 export './widgets/containers/sail_card.dart';
 export './widgets/containers/sail_column.dart';

--- a/packages/sail_ui/lib/widgets/containers/notification.dart
+++ b/packages/sail_ui/lib/widgets/containers/notification.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sail_ui/theme/theme.dart';
+
+class SailNotification extends StatelessWidget {
+  final String title;
+  final String content;
+  final DialogType dialogType;
+  final Function(String content) removeNotification;
+  final Function()? onPressed;
+
+  const SailNotification({
+    super.key,
+    required this.title,
+    required this.content,
+    required this.dialogType,
+    required this.removeNotification,
+    this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+
+    return Dismissible(
+      key: Key(content),
+      direction: DismissDirection.horizontal,
+      onDismissed: (direction) {
+        removeNotification(content);
+      },
+      child: SailScaleButton(
+        onPressed: onPressed,
+        child: Card(
+          color: theme.colors.actionHeader.withOpacity(0.8),
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    maxWidth: 250,
+                  ),
+                  child: Column(
+                    children: [
+                      Row(
+                        children: [
+                          SailSVG.fromAsset(SailSVGAsset.iconInfo, color: findColorForType(dialogType)),
+                          const SizedBox(width: 8),
+                          Text(
+                            title,
+                            style: const TextStyle(color: Colors.white),
+                            softWrap: true,
+                          ),
+                        ],
+                      ),
+                      Text(
+                        content,
+                        style: TextStyle(color: Colors.white.withOpacity(0.6)),
+                        softWrap: true,
+                        overflow: TextOverflow.visible,
+                      ),
+                    ],
+                  ),
+                ),
+                SailScaleButton(
+                  child: const Icon(
+                    Icons.close,
+                    color: Colors.white,
+                    size: 14,
+                  ),
+                  onPressed: () {
+                    removeNotification(content);
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color findColorForType(DialogType dialogType) {
+    switch (dialogType) {
+      case DialogType.info:
+        return SailColorScheme.blue;
+      case DialogType.error:
+        return SailColorScheme.red;
+      case DialogType.success:
+        return SailColorScheme.green;
+    }
+  }
+}

--- a/packages/sidesail/lib/config/dependencies.dart
+++ b/packages/sidesail/lib/config/dependencies.dart
@@ -7,6 +7,7 @@ import 'package:sidesail/pages/tabs/settings/node_settings_tab.dart';
 import 'package:sidesail/providers/balance_provider.dart';
 import 'package:sidesail/providers/bmm_provider.dart';
 import 'package:sidesail/providers/cast_provider.dart';
+import 'package:sidesail/providers/notification_provider.dart';
 import 'package:sidesail/providers/process_provider.dart';
 import 'package:sidesail/providers/transactions_provider.dart';
 import 'package:sidesail/providers/zcash_provider.dart';
@@ -29,6 +30,10 @@ final _emptyNodeConf = SingleNodeConnectionSettings.empty();
 Future<void> initDependencies(Sidechain chain) async {
   final log = await logger();
   GetIt.I.registerLazySingleton<Logger>(() => log);
+
+  GetIt.I.registerLazySingleton<NotificationProvider>(
+    () => NotificationProvider(),
+  );
 
   final sidechain = await findSubRPC(chain);
   final sidechainContainer = await SidechainContainer.create(sidechain);
@@ -159,7 +164,7 @@ Future<SidechainRPC> findSubRPC(Sidechain chain) async {
     );
     sidechain = zChain;
 
-    if (!GetIt.I.isRegistered<EthereumRPC>()) {
+    if (!GetIt.I.isRegistered<ZCashRPC>()) {
       GetIt.I.registerLazySingleton<ZCashRPC>(
         () => zChain,
       );

--- a/packages/sidesail/lib/pages/tabs/testchain/mainchain/transfer_mainchain_tab_route.dart
+++ b/packages/sidesail/lib/pages/tabs/testchain/mainchain/transfer_mainchain_tab_route.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:sail_ui/sail_ui.dart';
-import 'package:sail_ui/theme/theme.dart';
 import 'package:sail_ui/widgets/core/sail_text.dart';
 import 'package:sidesail/bitcoin.dart';
 import 'package:sidesail/config/sidechains.dart';
@@ -28,8 +27,6 @@ class TransferMainchainTabPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = SailTheme.of(context);
-
     return ViewModelBuilder.reactive(
       viewModelBuilder: () => TransferMainchainTabViewModel(),
       builder: ((context, viewModel, child) {
@@ -40,71 +37,45 @@ class TransferMainchainTabPage extends StatelessWidget {
               child: SailColumn(
                 spacing: SailStyleValues.padding30,
                 children: [
-                  SailRow(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    spacing: 0,
+                  SailColumn(
+                    spacing: SailStyleValues.padding30,
                     children: [
-                      Flexible(
-                        child: SailColumn(
-                          spacing: SailStyleValues.padding30,
-                          children: [
-                            DashboardGroup(
-                              title: 'Actions',
-                              children: [
-                                ActionTile(
-                                  title: 'Send on parent chain',
-                                  category: Category.mainchain,
-                                  icon: Icons.remove,
-                                  onTap: () {
-                                    viewModel.send(context);
-                                  },
-                                ),
-                                ActionTile(
-                                  title: 'Receive on parent chain',
-                                  category: Category.mainchain,
-                                  icon: Icons.add,
-                                  onTap: () {
-                                    viewModel.receive(context);
-                                  },
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                      VerticalDivider(
-                        width: 1,
-                        thickness: 1,
-                        color: theme.colors.divider,
-                      ),
-                      Flexible(
-                        child: SailColumn(
-                          spacing: SailStyleValues.padding30,
-                          children: [
-                            DashboardGroup(
-                              title: 'Actions',
-                              children: [
-                                ActionTile(
-                                  title: 'Peg-out to parent chain',
-                                  category: Category.mainchain,
-                                  icon: Icons.remove,
-                                  onTap: () {
-                                    viewModel.pegOut(context);
-                                  },
-                                ),
-                                ActionTile(
-                                  title: 'Peg-in from parent chain',
-                                  category: Category.mainchain,
-                                  icon: Icons.add,
-                                  onTap: () {
-                                    viewModel.pegIn(context);
-                                  },
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
+                      DashboardGroup(
+                        title: 'Actions',
+                        children: [
+                          ActionTile(
+                            title: 'Withdraw to parent chain',
+                            category: Category.mainchain,
+                            icon: Icons.remove,
+                            onTap: () {
+                              viewModel.pegOut(context);
+                            },
+                          ),
+                          ActionTile(
+                            title: 'Deposit from parent chain',
+                            category: Category.mainchain,
+                            icon: Icons.add,
+                            onTap: () {
+                              viewModel.pegIn(context);
+                            },
+                          ),
+                          ActionTile(
+                            title: 'Send on parent chain',
+                            category: Category.mainchain,
+                            icon: Icons.remove,
+                            onTap: () {
+                              viewModel.send(context);
+                            },
+                          ),
+                          ActionTile(
+                            title: 'Receive on parent chain',
+                            category: Category.mainchain,
+                            icon: Icons.add,
+                            onTap: () {
+                              viewModel.receive(context);
+                            },
+                          ),
+                        ],
                       ),
                     ],
                   ),
@@ -360,7 +331,7 @@ class SendViewModel extends BaseViewModel {
       await successDialog(
         context: context,
         action: 'Send on parent chain',
-        title: 'You sent $amount $ticker to $address',
+        title: 'You sent $amount BTC to $address',
         subtitle: 'TXID: $sendTXID',
       );
       // also pop the info modal

--- a/packages/sidesail/lib/pages/tabs/testchain/mainchain/withdrawal_bundle_tab_page.dart
+++ b/packages/sidesail/lib/pages/tabs/testchain/mainchain/withdrawal_bundle_tab_page.dart
@@ -372,7 +372,7 @@ class _BundleViewState extends State<BundleView> {
               label:
                   widget.bundle.status == BundleStatus.failed ? 'Failed' : '${widget.votes}/$bundleVotesRequired ACKs',
               value:
-                  'Peg-out of ${widget.bundle.totalBitcoin.toStringAsFixed(8)} BTC in ${widget.bundle.withdrawals.length} transactions',
+                  'Withdraw of ${widget.bundle.totalBitcoin.toStringAsFixed(8)} BTC in ${widget.bundle.withdrawals.length} transactions',
             ),
           ),
           if (expanded) ExpandedBundleView(timesOutIn: widget.timesOutIn, bundle: widget.bundle),

--- a/packages/sidesail/lib/pages/tabs/zcash/zcash_melt_cast_page.dart
+++ b/packages/sidesail/lib/pages/tabs/zcash/zcash_melt_cast_page.dart
@@ -41,31 +41,6 @@ class ZCashMeltCastTabPage extends StatelessWidget {
             child: SailColumn(
               spacing: SailStyleValues.padding30,
               children: [
-                DashboardGroup(
-                  title: 'Operation statuses',
-                  endWidget: SailTextButton(
-                    label: 'Clear',
-                    onPressed: () => viewModel.clear(),
-                  ),
-                  children: [
-                    SailColumn(
-                      spacing: 0,
-                      withDivider: true,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        ListView.builder(
-                          shrinkWrap: true,
-                          physics: const NeverScrollableScrollPhysics(),
-                          itemCount: viewModel.operations.length,
-                          itemBuilder: (context, index) => OperationView(
-                            key: ValueKey<String>(viewModel.operations[index].id),
-                            tx: viewModel.operations[index],
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
                 SailRow(
                   mainAxisAlignment: MainAxisAlignment.start,
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -225,7 +200,6 @@ class ZCashCastTabViewModel extends BaseViewModel {
       _zcashProvider.utxosToMelt.where((element) => element.executeTime.isAfter(DateTime.now())).toList();
   List<PendingCastBill> get pendingNonEmptyBills =>
       _castProvider.futureCasts.where((element) => element.pendingShields.isNotEmpty).toList();
-  List<OperationStatus> get operations => _zcashProvider.operations.reversed.toList();
   List<UnshieldedUTXO> get unshieldedUTXOs =>
       _zcashProvider.unshieldedUTXOs.where((u) => !hideDust || u.amount > 0.0001).toList();
   List<ShieldedUTXO> get shieldedUTXOs => _zcashProvider.shieldedUTXOs;
@@ -241,12 +215,8 @@ class ZCashCastTabViewModel extends BaseViewModel {
 
   ZCashCastTabViewModel() {
     _zcashProvider.addListener(notifyListeners);
+    _castProvider.addListener(notifyListeners);
     _balanceProvider.addListener(notifyListeners);
-  }
-
-  Future<void> clear() async {
-    _zcashProvider.operations = List.empty();
-    notifyListeners();
   }
 
   void melt(BuildContext context) async {
@@ -289,6 +259,7 @@ class ZCashCastTabViewModel extends BaseViewModel {
   void dispose() {
     super.dispose();
     _zcashProvider.removeListener(notifyListeners);
+    _castProvider.removeListener(notifyListeners);
     _balanceProvider.removeListener(notifyListeners);
   }
 }

--- a/packages/sidesail/lib/pages/tabs/zcash/zcash_operation_statuses.dart
+++ b/packages/sidesail/lib/pages/tabs/zcash/zcash_operation_statuses.dart
@@ -1,0 +1,92 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sidesail/pages/tabs/home_page.dart';
+import 'package:sidesail/pages/tabs/zcash/zcash_transfer_page.dart';
+import 'package:sidesail/providers/zcash_provider.dart';
+import 'package:sidesail/routing/router.dart';
+import 'package:sidesail/rpc/models/zcash_utxos.dart';
+import 'package:sidesail/widgets/containers/tabs/dashboard_tab_widgets.dart';
+import 'package:sidesail/widgets/containers/tabs/zcash_tab_widgets.dart';
+import 'package:stacked/stacked.dart';
+
+@RoutePage()
+class ZCashOperationStatusesTabPage extends StatelessWidget {
+  AppRouter get router => GetIt.I.get<AppRouter>();
+
+  const ZCashOperationStatusesTabPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewModelBuilder.reactive(
+      viewModelBuilder: () => OperationStatusesiewModel(),
+      builder: ((context, viewModel, child) {
+        final tabsRouter = AutoTabsRouter.of(context);
+
+        return SailPage(
+          scrollable: true,
+          widgetTitle: ZCashWidgetTitle(
+            depositNudgeAction: () => tabsRouter.setActiveIndex(ParentChainHome),
+          ),
+          body: Padding(
+            padding: const EdgeInsets.only(bottom: SailStyleValues.padding30),
+            child: SailColumn(
+              spacing: SailStyleValues.padding30,
+              children: [
+                DashboardGroup(
+                  title: 'Operation statuses',
+                  endWidget: SailTextButton(
+                    label: 'Clear',
+                    onPressed: () => viewModel.clear(),
+                  ),
+                  children: [
+                    SailColumn(
+                      spacing: 0,
+                      withDivider: true,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ListView.builder(
+                          shrinkWrap: true,
+                          physics: const NeverScrollableScrollPhysics(),
+                          itemCount: viewModel.operations.length,
+                          itemBuilder: (context, index) => OperationView(
+                            key: ValueKey<String>(viewModel.operations[index].id),
+                            tx: viewModel.operations[index],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class OperationStatusesiewModel extends BaseViewModel {
+  final log = Logger(level: Level.debug);
+  ZCashProvider get _zcashProvider => GetIt.I.get<ZCashProvider>();
+
+  List<OperationStatus> get operations => _zcashProvider.operations.reversed.toList();
+
+  OperationStatusesiewModel() {
+    _zcashProvider.addListener(notifyListeners);
+  }
+
+  Future<void> clear() async {
+    _zcashProvider.operations = List.empty();
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _zcashProvider.removeListener(notifyListeners);
+  }
+}

--- a/packages/sidesail/lib/pages/tabs/zcash/zcash_shield_deshield_page.dart
+++ b/packages/sidesail/lib/pages/tabs/zcash/zcash_shield_deshield_page.dart
@@ -40,31 +40,6 @@ class ZCashShieldDeshieldTabPage extends StatelessWidget {
             child: SailColumn(
               spacing: SailStyleValues.padding30,
               children: [
-                DashboardGroup(
-                  title: 'Operation statuses',
-                  endWidget: SailTextButton(
-                    label: 'Clear',
-                    onPressed: () => viewModel.clear(),
-                  ),
-                  children: [
-                    SailColumn(
-                      spacing: 0,
-                      withDivider: true,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        ListView.builder(
-                          shrinkWrap: true,
-                          physics: const NeverScrollableScrollPhysics(),
-                          itemCount: viewModel.operations.length,
-                          itemBuilder: (context, index) => OperationView(
-                            key: ValueKey<String>(viewModel.operations[index].id),
-                            tx: viewModel.operations[index],
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
                 SailRow(
                   spacing: 0,
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -138,7 +113,6 @@ class ZCashShieldTabViewModel extends BaseViewModel {
   BalanceProvider get _balanceProvider => GetIt.I.get<BalanceProvider>();
 
   String get zcashAddress => _zcashProvider.zcashAddress;
-  List<OperationStatus> get operations => _zcashProvider.operations.reversed.toList();
   List<UnshieldedUTXO> get unshieldedUTXOs =>
       _zcashProvider.unshieldedUTXOs.where((u) => !hideDust || u.amount > 0.0001).toList();
   List<ShieldedUTXO> get shieldedUTXOs => _zcashProvider.shieldedUTXOs;
@@ -155,11 +129,6 @@ class ZCashShieldTabViewModel extends BaseViewModel {
   ZCashShieldTabViewModel() {
     _zcashProvider.addListener(notifyListeners);
     _balanceProvider.addListener(notifyListeners);
-  }
-
-  Future<void> clear() async {
-    _zcashProvider.operations = List.empty();
-    notifyListeners();
   }
 
   void melt(BuildContext context) async {

--- a/packages/sidesail/lib/pages/tabs/zcash/zcash_transfer_page.dart
+++ b/packages/sidesail/lib/pages/tabs/zcash/zcash_transfer_page.dart
@@ -296,7 +296,7 @@ class ZCashWidgetTitle extends StatelessWidget {
               size: ButtonSize.small,
             ),
             SailText.secondary12(
-              'To get started, you must deposit coins to your sidechain. Peg-In on the Parent Chain tab',
+              'To get started, you must deposit coins to your sidechain. Deposit on the Parent Chain tab',
             ),
             Expanded(child: Container()),
           ],

--- a/packages/sidesail/lib/providers/balance_provider.dart
+++ b/packages/sidesail/lib/providers/balance_provider.dart
@@ -46,7 +46,6 @@ class BalanceProvider extends ChangeNotifier {
         notifyListeners();
       }
     } catch (err) {
-      // ignore: avoid_print
       log.e('could not get balance $err');
     } finally {
       _isFetching = false;

--- a/packages/sidesail/lib/providers/notification_provider.dart
+++ b/packages/sidesail/lib/providers/notification_provider.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logger/logger.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+class NotificationProvider extends ChangeNotifier {
+  final List<Widget> notifications = [];
+  Logger log = GetIt.I.get<Logger>();
+
+  final Function()? onPressed;
+
+  NotificationProvider({this.onPressed});
+
+  void add({
+    required String title,
+    required String content,
+    required DialogType dialogType,
+    Function()? onPressed,
+  }) {
+    final notification = SailNotification(
+      title: title,
+      content: content,
+      removeNotification: (content) => notifications.removeWhere((element) => element.key == Key(content)),
+      dialogType: dialogType,
+      onPressed: onPressed,
+    );
+
+    notifications.insert(0, notification);
+    if (notifications.length > 3) {
+      // only show 3 notifications at a time
+      notifications.removeLast();
+    }
+    notifyListeners();
+
+    // Automatically dismiss the notification after a set duration
+    Future.delayed(const Duration(seconds: 4), () {
+      notifications.remove(notification);
+      notifyListeners();
+    });
+  }
+}

--- a/packages/sidesail/lib/providers/zcash_provider.dart
+++ b/packages/sidesail/lib/providers/zcash_provider.dart
@@ -20,7 +20,7 @@ class ZCashProvider extends ChangeNotifier {
   List<OperationStatus> operations = [];
   List<ShieldedUTXO> shieldedUTXOs = [];
   List<UnshieldedUTXO> unshieldedUTXOs = [];
-  double sideFee = 0.00001;
+  double sideFee = 0.0001;
 
   bool _isFetching = false;
 

--- a/packages/sidesail/lib/routing/router.dart
+++ b/packages/sidesail/lib/routing/router.dart
@@ -13,6 +13,7 @@ import 'package:sidesail/pages/tabs/testchain/mainchain/transfer_mainchain_tab_r
 import 'package:sidesail/pages/tabs/testchain/mainchain/withdrawal_bundle_tab_page.dart';
 import 'package:sidesail/pages/tabs/testchain/testchain_rpc_tab_page.dart';
 import 'package:sidesail/pages/tabs/zcash/zcash_melt_cast_page.dart';
+import 'package:sidesail/pages/tabs/zcash/zcash_operation_statuses.dart';
 import 'package:sidesail/pages/tabs/zcash/zcash_rpc_tab_page.dart';
 import 'package:sidesail/pages/tabs/zcash/zcash_shield_deshield_page.dart';
 import 'package:sidesail/pages/tabs/zcash/zcash_transfer_page.dart';
@@ -74,6 +75,9 @@ class AppRouter extends _$AppRouter {
             ),
             AutoRoute(
               page: ZCashTransferTabRoute.page,
+            ),
+            AutoRoute(
+              page: ZCashOperationStatusesTabRoute.page,
             ),
             AutoRoute(
               page: ZCashRPCTabRoute.page,

--- a/packages/sidesail/lib/routing/router.gr.dart
+++ b/packages/sidesail/lib/routing/router.gr.dart
@@ -91,6 +91,12 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const ZCashMeltCastTabPage(),
       );
     },
+    ZCashOperationStatusesTabRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const ZCashOperationStatusesTabPage(),
+      );
+    },
     ZCashRPCTabRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
@@ -299,6 +305,20 @@ class ZCashMeltCastTabRoute extends PageRouteInfo<void> {
         );
 
   static const String name = 'ZCashMeltCastTabRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [ZCashOperationStatusesTabPage]
+class ZCashOperationStatusesTabRoute extends PageRouteInfo<void> {
+  const ZCashOperationStatusesTabRoute({List<PageRouteInfo>? children})
+      : super(
+          ZCashOperationStatusesTabRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'ZCashOperationStatusesTabRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
 }

--- a/packages/sidesail/lib/rpc/rpc_testchain.dart
+++ b/packages/sidesail/lib/rpc/rpc_testchain.dart
@@ -91,7 +91,7 @@ class TestchainRPCLive extends TestchainRPC {
       mainchainFee,
     ]);
 
-    log.d('created peg-out: ${withdrawalTxid['txid']}');
+    log.d('created withdraw: ${withdrawalTxid['txid']}');
 
     return withdrawalTxid['txid'];
   }

--- a/packages/sidesail/lib/rpc/rpc_zcash.dart
+++ b/packages/sidesail/lib/rpc/rpc_zcash.dart
@@ -261,7 +261,7 @@ class ZcashRPCLive extends ZCashRPC {
 
   @override
   Future<double> sideEstimateFee() async {
-    return 0.00001;
+    return 0.0001;
   }
 
   Future<String> _getNewShieldedAddress() async {
@@ -286,10 +286,14 @@ class ZcashRPCLive extends ZCashRPC {
 
   @override
   Future<String> sideSend(String address, double amount, bool subtractFeeFromAmount) async {
-    amount = cleanAmount(amount);
+    var fee = await sideEstimateFee();
 
+    amount = cleanAmount(amount);
+    fee = cleanAmount(fee);
+
+    final zAddress = await sideGenerateAddress();
     final txid = await _client().call('z_sendmany', [
-      'ANY_TADDR',
+      zAddress,
       [
         {
           'address': address,
@@ -297,6 +301,7 @@ class ZcashRPCLive extends ZCashRPC {
         }
       ],
       1,
+      fee,
     ]);
 
     return txid;

--- a/packages/sidesail/lib/widgets/containers/tabs/home/side_nav.dart
+++ b/packages/sidesail/lib/widgets/containers/tabs/home/side_nav.dart
@@ -171,9 +171,9 @@ class _SideNavState extends State<SideNav> {
             subs: [
               SubNavEntry(
                 title: 'Transfer',
-                selected: tabsRouter.activeIndex == ZCashHome + 3,
+                selected: tabsRouter.activeIndex == ZCashHome + 2,
                 onPressed: () {
-                  tabsRouter.setActiveIndex(ZCashHome + 3);
+                  tabsRouter.setActiveIndex(ZCashHome + 2);
                 },
               ),
             ],
@@ -197,10 +197,17 @@ class _SideNavState extends State<SideNav> {
                 },
               ),
               SubNavEntry(
-                title: 'Send RPC',
-                selected: tabsRouter.activeIndex == ZCashHome + 2,
+                title: 'Operation Statuses',
+                selected: tabsRouter.activeIndex == ZCashHome + 3,
                 onPressed: () {
-                  tabsRouter.setActiveIndex(ZCashHome + 2);
+                  tabsRouter.setActiveIndex(ZCashHome + 3);
+                },
+              ),
+              SubNavEntry(
+                title: 'Send RPC',
+                selected: tabsRouter.activeIndex == ZCashHome + 4,
+                onPressed: () {
+                  tabsRouter.setActiveIndex(ZCashHome + 4);
                 },
               ),
             ],
@@ -245,9 +252,9 @@ class _SideNavState extends State<SideNav> {
             ],
           ),
         ];
-      case 2 || 3 || 4 || 5 || 6 || 7 || 8 || 9 || 10:
+      case 2 || 3 || 4 || 5 || 6 || 7 || 8 || 9 || 10 || 11:
         return _navForChain(chain, viewModel, tabsRouter);
-      case 11 || 12:
+      case 12 || 13:
         return [
           const NavCategory(category: 'Settings'),
           SubNavEntryContainer(

--- a/packages/sidesail/lib/widgets/containers/tabs/home/top_nav.dart
+++ b/packages/sidesail/lib/widgets/containers/tabs/home/top_nav.dart
@@ -114,9 +114,10 @@ class _TopNavState extends State<TopNav> {
             activeIndex == ZCashHome ||
             activeIndex == ZCashHome + 1 ||
             activeIndex == ZCashHome + 2 ||
-            activeIndex == ZCashHome + 3;
+            activeIndex == ZCashHome + 3 ||
+            activeIndex == ZCashHome + 4;
       case 2:
-        return activeIndex == 11 || activeIndex == 12;
+        return activeIndex == 12 || activeIndex == 13;
       default:
         return true;
     }

--- a/packages/sidesail/lib/widgets/containers/tabs/transfer_mainchain_tab_widgets.dart
+++ b/packages/sidesail/lib/widgets/containers/tabs/transfer_mainchain_tab_widgets.dart
@@ -27,9 +27,9 @@ class PegOutAction extends StatelessWidget {
       viewModelBuilder: () => PegOutViewModel(staticAddress: staticAddress),
       builder: ((context, viewModel, child) {
         return DashboardActionModal(
-          'Peg-out to parent chain',
+          'Withdraw to parent chain',
           endActionButton: SailButton.primary(
-            'Execute peg-out',
+            'Execute withdraw',
             disabled: viewModel.bitcoinAddressController.text.isEmpty || viewModel.bitcoinAmountController.text.isEmpty,
             loading: viewModel.isBusy,
             size: ButtonSize.regular,
@@ -155,7 +155,7 @@ class PegOutViewModel extends BaseViewModel {
     double mainchainFee,
   ) async {
     log.i(
-      'doing peg-out: $amount BTC to $address for $sidechainFee SC fee and $mainchainFee MC fee',
+      'doing withdraw: $amount BTC to $address for $sidechainFee SC fee and $mainchainFee MC fee',
     );
 
     try {
@@ -181,14 +181,14 @@ class PegOutViewModel extends BaseViewModel {
 
       await successDialog(
         context: context,
-        action: 'Peg-out to parent chain',
-        title: 'Submitted peg-out successfully',
+        action: 'Withdraw to parent chain',
+        title: 'Submitted withdraw successfully',
         subtitle: 'TXID: $withdrawalTxid',
       );
       // also pop the info modal
       await _router.pop();
     } catch (error) {
-      log.e('could not execute peg-out: $error', error: error);
+      log.e('could not execute withdraw: $error', error: error);
 
       if (!context.mounted) {
         return;
@@ -196,8 +196,8 @@ class PegOutViewModel extends BaseViewModel {
 
       await errorDialog(
         context: context,
-        action: 'Peg-out to parent chain',
-        title: 'Could not execute peg-out',
+        action: 'Withdraw to parent chain',
+        title: 'Could not execute withdraw',
         subtitle: error.toString(),
       );
     }
@@ -213,7 +213,7 @@ class PegInAction extends StatelessWidget {
       viewModelBuilder: () => PegInViewModel(),
       builder: ((context, viewModel, child) {
         return DashboardActionModal(
-          'Peg-in from parent chain',
+          'Deposit from parent chain',
           endActionButton: SailButton.primary(
             'Generate new address',
             loading: viewModel.isBusy,
@@ -260,7 +260,7 @@ class PegInEthAction extends StatelessWidget {
       viewModelBuilder: () => PegInEthViewModel(),
       builder: ((context, viewModel, child) {
         return DashboardActionModal(
-          'Peg-in from parent chain',
+          'Deposit from parent chain',
           endActionButton: SailButton.primary(
             'Deposit funds',
             loading: viewModel.isBusy,
@@ -354,14 +354,14 @@ class PegInEthViewModel extends BaseViewModel {
 
       await successDialog(
         context: context,
-        action: 'Peg-in from parent chain',
+        action: 'Deposit from parent chain',
         title: 'Deposited from parent-chain successfully',
         subtitle: '',
       );
       // also pop the info modal
       await _router.pop();
     } catch (error) {
-      log.e('could not execute peg-out: $error', error: error);
+      log.e('could not execute withdraw: $error', error: error);
 
       if (!context.mounted) {
         return;
@@ -369,7 +369,7 @@ class PegInEthViewModel extends BaseViewModel {
 
       await errorDialog(
         context: context,
-        action: 'Peg-in from parent chain',
+        action: 'Deposit from parent chain',
         title: 'Could not deposit from parent-chain',
         subtitle: error.toString(),
       );


### PR DESCRIPTION
- ui: add notification widget
- providers: add notification provider
- tabs/home: show notifications on home page when added
- tabs/mainchaintransfer: stack actions on top of each other
- multi: rename peg to withdraw/deposit
- tabs/zcash: move operation statuses to separate sub-page
- tabs: add optional max amount to send sidechain action
- rpc/zcash: increase fee to allow for many utxo-transactions
- providers/zcash: add notification every time a new operation is added
